### PR TITLE
fix(Dockerfile): pin alpine image tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Imagem de contêiner que executa seu código
-FROM alpine:latest
+FROM alpine:3.19
 
 RUN apk update && apk add curl aws-cli \
 && curl -o aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.19.6/2021-01-05/bin/linux/amd64/aws-iam-authenticator \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Imagem de contêiner que executa seu código
-FROM alpine:3.19
+FROM alpine:3.19.1
 
 RUN apk update && apk add curl aws-cli \
 && curl -o aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.19.6/2021-01-05/bin/linux/amd64/aws-iam-authenticator \

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Action for kubectl
 ## How To use
 ### Basic
 ```
-- uses: Gabryel8818/kubectl@v1.0.1
+- uses: Gabryel8818/kubectl@v1.0.5
   env:
     BASE64_KUBE_CONFIG: ${{ secrets.KUBE_CONFIG_DATA }}
     KUBECTL_VERSION: '1.23.6'


### PR DESCRIPTION
aws-cli got disabled in Alpine 3.20 due to missing Python 3.12 compat. 

Ref: https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.20.0#aws-cli

docker build output:

```
$ docker build .
[+] Building 84.9s (8/8) FINISHED                                                                                                                                              docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                     0.0s
 => => transferring dockerfile: 778B                                                                                                                                                     0.0s
 => [internal] load metadata for docker.io/library/alpine:3.19.1                                                                                                                         6.6s
 => [internal] load .dockerignore                                                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                                                          0.0s
 => [1/3] FROM docker.io/library/alpine:3.19.1@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b                                                                   0.0s
 => => resolve docker.io/library/alpine:3.19.1@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b                                                                   0.0s
 => => sha256:05455a08881ea9cf0e752bc48e61bbd71a34c029bb13df01e40e3e70e0d007bd 1.47kB / 1.47kB                                                                                           0.0s
 => => sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b 1.64kB / 1.64kB                                                                                           0.0s
 => => sha256:6457d53fb065d6f250e1504b9bc42d5b6c65941d57532c072d929dd0628977d0 528B / 528B                                                                                               0.0s
 => [internal] load build context                                                                                                                                                        0.0s
 => => transferring context: 434B                                                                                                                                                        0.0s
 => [2/3] RUN apk update && apk add curl aws-cli && curl -o aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.19.6/2021-01-05/bin/linux/amd64/aws-iam-authenticato  77.0s
 => [3/3] COPY entrypoint.sh /entrypoint.sh                                                                                                                                              0.0s 
 => exporting to image                                                                                                                                                                   1.2s 
 => => exporting layers                                                                                                                                                                  1.2s 
 => => writing image sha256:f5990bb6fe27ef96f7d460cbc9a826a50b5d53064d3de38f52d79a6a0cb72ad9
```